### PR TITLE
Upgrade for FriendsOfBehat\SymfonyExtension^2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,36 +26,19 @@ Requires the FriendsOfBehat [SymfonyExtension](https://github.com/FriendsOfBehat
 
         extensions:
             Persata\SymfonyApiExtension: ~
-            FriendsOfBehat\SymfonyExtension:
-                kernel:
-                    bootstrap: vendor/autoload.php
+			FriendsOfBehat\SymfonyExtension:
+				bootstrap: config/bootstrap.php
+				kernel:
+					class: App\Kernel
+					path: src/Kernel.php
+					environment: test
+					debug: true
     ```
 
 ## Additional Custom Contexts
 
 This package provides a `ContextInitializer` that will set the shared `ApiClient` on any Behat Contexts that implement the `ApiClientAwareContext`. It is best to extend the `RawApiContext` as this already includes the getter & setter for the `ApiClient` instance.
 
-## ContextServiceExtension Integration
-
-If using the FriendsOfBehat [ContextServiceExtension](https://github.com/FriendsOfBehat/ContextServiceExtension), declare the `ApiContext` service like so:
-
-```yaml
-services:
-    # ...
-    Persata\SymfonyApiExtension\Context\ApiContext:
-        tags:
-            - { name: fob.context_service }
-```
-
-If you need additional context services with access to the same shared ApiClient instance, have them extend `RawApiContext` and then declare the service like so:
-
-```yaml
-services:
-    # ...
-    TheClass\Of\Your\CustomContext:
-        tags:
-            - { name: fob.context_service }
-```
 
 ## FOSRest Form Validation
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Requires the FriendsOfBehat [SymfonyExtension](https://github.com/FriendsOfBehat
 
         extensions:
             Persata\SymfonyApiExtension: ~
-			FriendsOfBehat\SymfonyExtension:
-				bootstrap: config/bootstrap.php
-				kernel:
-					class: App\Kernel
-					path: src/Kernel.php
-					environment: test
-					debug: true
+            FriendsOfBehat\SymfonyExtension:
+                bootstrap: config/bootstrap.php
+                kernel:
+                    class: App\Kernel
+                    path: src/Kernel.php
+                    environment: test
+                    debug: true
     ```
 
 ## Additional Custom Contexts

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "webmozart/assert": "^1.0",
         "symfony/http-kernel": "^3.0|^4.0",
         "symfony/browser-kit": "^3.0|^4.0",
-        "friends-of-behat/symfony-extension": "^0.2.1|^1.0"
+        "friends-of-behat/symfony-extension": "^^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6"

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,6 @@
     "require-dev": {
         "phpunit/phpunit": "^6"
     },
-    "suggest": {
-        "friends-of-behat/cross-container-extension": "^1.0",
-        "friends-of-behat/context-service-extension": "^1.0"
-    },
     "autoload": {
         "psr-4": {
             "Persata\\SymfonyApiExtension\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "webmozart/assert": "^1.0",
         "symfony/http-kernel": "^3.0|^4.0",
         "symfony/browser-kit": "^3.0|^4.0",
-        "friends-of-behat/symfony-extension": "^^2.0"
+        "friends-of-behat/symfony-extension": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6"

--- a/src/ServiceContainer/SymfonyApiExtension.php
+++ b/src/ServiceContainer/SymfonyApiExtension.php
@@ -89,7 +89,7 @@ class SymfonyApiExtension implements ExtensionInterface
     public function load(ContainerBuilder $container, array $config)
     {
         $container->setDefinition(self::API_CLIENT_ID, new Definition(ApiClient::class, [
-            new Reference(SymfonyExtension::DRIVER_KERNEL_ID),
+            new Reference(SymfonyExtension::KERNEL_ID),
             $config['base_url']
         ]));
 


### PR DESCRIPTION
Upgrading the FriendsOfBehat\SymfonyExtension version and removing `ContextServiceExtension Integration` from Readme as this is no longer needed with version 2 